### PR TITLE
Fix PyPy-specific bugs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   - TOX_ENV=py27-unit
   - TOX_ENV=py27-lint
   - TOX_ENV=py27-func
+  - TOX_ENV=pypy-unit
+  - TOX_ENV=pypy-func
   - TOX_ENV=docs
 install:
   - pip install tox

--- a/ncolony/tests/test_ctllib.py
+++ b/ncolony/tests/test_ctllib.py
@@ -34,8 +34,8 @@ class TestArgParsing(unittest.TestCase):
     def test_restart_all(self):
         """Check restart-all subcommand parsing"""
         res = self.parser.parse_args(self.base+['restart-all'])
-        self.assertIs(res.messages, 'messages')
-        self.assertIs(res.config, 'config')
+        self.assertEquals(res.messages, 'messages')
+        self.assertEquals(res.config, 'config')
         self.assertIs(res.func, ctllib.restartAll)
 
     def test_restart(self):

--- a/ncolony/tests/test_directory_monitor.py
+++ b/ncolony/tests/test_directory_monitor.py
@@ -94,7 +94,8 @@ class DirectoryBasedTest(unittest.TestCase):
     def write(self, name, content):
         """Write a file in the directory"""
         name = os.path.join(self.testDirectory, name)
-        file(name, 'w').write(content)
+        with file(name, 'w') as fp:
+            fp.write(content)
 
     def remove(self, name):
         """Remove a file from the directory"""

--- a/ncolony/tests/test_service.py
+++ b/ncolony/tests/test_service.py
@@ -118,7 +118,8 @@ class TestService(unittest.TestCase):
 
     def _write(self, tp, name, content):
         name = os.path.join(self.testDirs[tp], name)
-        file(name, 'w').write(content)
+        with file(name, 'w') as fp:
+            fp.write(content)
 
     def _remove(self, tp, name):
         name = os.path.join(self.testDirs[tp], name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Copyright (c) Moshe Zadka
 # See LICENSE for details.
 [tox]
-envlist = py27-{unit,func,lint},docs
+envlist = {py27,pypy}-{unit,func},py27-lint,docs
 toxworkdir = {toxinidir}/build/.tox
 
 [testenv]
@@ -10,10 +10,10 @@ deps =
     {py27,pypy}-lint: pylint
     {py27,pypy}-{func,unit}: Twisted
 commands =
-    {py27,pypy}-unit: coverage run {envbindir}/trial --temp-directory build/_trial_temp ncolony
+    {py27,pypy}-unit: coverage run {envbindir}/trial --temp-directory build/_trial_temp {posargs:ncolony}
     {py27,pypy}-unit: coverage report --include ncolony* --omit ncolony/tests/*,ncolony/interfaces* --show-missing --fail-under=100
-    {py27,pypy}-lint: pylint --rcfile admin/pylintrc ncolony
-    {py27,pypy}-lint: python -m ncolony.tests.nitpicker
+    py27-lint: pylint --rcfile admin/pylintrc ncolony
+    py27-lint: python -m ncolony.tests.nitpicker
     {py27,pypy}-func: python -m ncolony.tests.functional_test
 
 [testenv:docs]


### PR DESCRIPTION
Stop assuming strings that are equal
have "is" relationship. Stop assuming
file objects close when they go out
of scope.